### PR TITLE
Update gulp-script to new gulp api

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,130 +1,127 @@
-'use strict';
+"use strict";
 
-var gulp = require('gulp')
-var inject = require('gulp-inject')
-var sass = require('gulp-sass')
-var importCss = require('gulp-import-css')
-var autoprefixer = require('gulp-autoprefixer')
-var sourcemaps = require('gulp-sourcemaps')
-var concat = require('gulp-concat')
-var cssmin = require('gulp-cssmin')
-var watch = require('gulp-watch')
-var swPrecache = require('sw-precache')
-var uglify = require('gulp-uglify')
-var replace = require('gulp-replace')
+var gulp = require("gulp");
+var inject = require("gulp-inject");
+var sass = require("gulp-sass");
+var importCss = require("gulp-import-css");
+var autoprefixer = require("gulp-autoprefixer");
+var sourcemaps = require("gulp-sourcemaps");
+var concat = require("gulp-concat");
+var cssmin = require("gulp-cssmin");
+var watch = require("gulp-watch");
+var swPrecache = require("sw-precache");
+var uglify = require("gulp-uglify");
+var replace = require("gulp-replace");
 
-
-
-gulp.task('version', function () {
-    var time = new Date().getTime()
-    return gulp.src(['views/base.html.twig'])
-    .pipe(replace(/version\s=\s\'\d*\'/g, 'version = \''+time+'\''))
-    .pipe(gulp.dest('views'));
-
+gulp.task("version", function() {
+  var time = new Date().getTime();
+  return gulp
+    .src(["views/base.html.twig"])
+    .pipe(replace(/version\s=\s\'\d*\'/g, "version = '" + time + "'"))
+    .pipe(gulp.dest("views"));
 });
 
-
-
 // service worker generator
-gulp.task('sw', function(callback) {
-  var packageJson = require('./package.json');
-  var bundleUrl = '/public/';
+gulp.task("sw", function(callback) {
+  var packageJson = require("./package.json");
+  var bundleUrl = "/public/";
 
   swPrecache.write(
-    'public/sw.js',
+    "public/sw.js",
     {
       cacheId: packageJson.name,
 
-      runtimeCaching: [{
-        urlPattern: /(googleapis|gstatic)/,
-        handler: 'cacheFirst',
-        options: {
-          cache: {
-            maxEntries: 200,
-            name: 'googleapis-cache'
+      runtimeCaching: [
+        {
+          urlPattern: /(googleapis|gstatic)/,
+          handler: "cacheFirst",
+          options: {
+            cache: {
+              maxEntries: 200,
+              name: "googleapis-cache"
+            }
+          }
+        },
+        {
+          urlPattern: /(media)/,
+          handler: "cacheFirst",
+          options: {
+            cache: {
+              maxEntries: 50,
+              name: "media-cache"
+            }
           }
         }
-      },
-      {
-        urlPattern: /(media)/,
-        handler: 'cacheFirst',
-        options: {
-          cache: {
-            maxEntries: 50,
-            name: 'media-cache'
-          }
-        }
-      }
       ],
-      staticFileGlobs: ['public/dist/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff}','public/img/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff}', 'public/fonts/**/*.{svg,eot,ttf,woff}'],
+      staticFileGlobs: [
+        "public/dist/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff}",
+        "public/img/**/*.{js,html,css,png,jpg,gif,svg,eot,ttf,woff}",
+        "public/fonts/**/*.{svg,eot,ttf,woff}"
+      ],
       stripPrefixMulti: {
-        'public/': bundleUrl
+        "public/": bundleUrl
       },
-      importScripts: ['/public/sw-contentCaching.js']
+      importScripts: ["/public/sw-contentCaching.js"]
     },
     callback
-
-    );
+  );
 });
 
-
-gulp.task('sass', function(){
- return gulp.src('public/dist/style.scss')
- .pipe(inject(gulp.src(['public/css/**/*.css', 'public/css/**/*.+(sass|scss)'], {read: false}), {
-     starttag: '/*injector*/',
-     endtag: ' /*endinjector*/',
-     transform: function (filePath, file) {
-       filePath = filePath.replace('/public/css/','../css/');
-       return '\n@import \'' + filePath + '\';';
-     }
-   })
- )
-  .pipe(sourcemaps.init())
-  .pipe(sass.sync().on('error', sass.logError))
-  .pipe(sourcemaps.write('./'))
-  .pipe(gulp.dest("public/dist/"));
-
-
+gulp.task("sass", function() {
+  return gulp
+    .src("public/dist/style.scss")
+    .pipe(
+      inject(
+        gulp.src(["public/css/**/*.css", "public/css/**/*.+(sass|scss)"], {
+          read: false
+        }),
+        {
+          starttag: "/*injector*/",
+          endtag: " /*endinjector*/",
+          transform: function(filePath, file) {
+            filePath = filePath.replace("/public/css/", "../css/");
+            return "\n@import '" + filePath + "';";
+          }
+        }
+      )
+    )
+    .pipe(sourcemaps.init())
+    .pipe(sass.sync().on("error", sass.logError))
+    .pipe(sourcemaps.write("./"))
+    .pipe(gulp.dest("public/dist/"));
 });
 
-
-
-gulp.task('js',function(){
- return gulp.src(['public/js/vendor/**/*.js','public/js/scripts/**/*.js'])
-     .pipe(sourcemaps.init())
-     .pipe(concat('all.js'))
-     .pipe(sourcemaps.write())
-     .pipe(gulp.dest('public/dist'));
-
-
+gulp.task("js", function() {
+  return gulp
+    .src(["public/js/vendor/**/*.js", "public/js/scripts/**/*.js"])
+    .pipe(sourcemaps.init())
+    .pipe(concat("all.js"))
+    .pipe(sourcemaps.write())
+    .pipe(gulp.dest("public/dist"));
 });
 
-gulp.task('cssmin', ['sass'],function(){
-  return gulp.src('public/dist/style.css')
-  .pipe(importCss())
-  .pipe(autoprefixer({ browsers: ['last 2 version'], cascade: false }))
-  .pipe(cssmin())
-  .pipe(gulp.dest('public/dist'));
-
+gulp.task("cssmin", ["sass"], function() {
+  return gulp
+    .src("public/dist/style.css")
+    .pipe(importCss())
+    .pipe(autoprefixer({ browsers: ["last 2 version"], cascade: false }))
+    .pipe(cssmin())
+    .pipe(gulp.dest("public/dist"));
 });
 
-gulp.task('jsmin', ['js'],function(){
-  return gulp.src('public/dist/all.js')
-  .pipe(uglify())
-  .pipe(gulp.dest('public/dist'));
-
+gulp.task("jsmin", ["js"], function() {
+  return gulp
+    .src("public/dist/all.js")
+    .pipe(uglify())
+    .pipe(gulp.dest("public/dist"));
 });
 
+gulp.task("build", ["sass", "js", "cssmin", "jsmin", "version", "sw"]);
 
-
-gulp.task('build', ['sass', 'js', 'cssmin' , 'jsmin','version', 'sw' ]);
-
-gulp.task('watch', function() {
+gulp.task("watch", function() {
   //empty service worker
-  require('fs').writeFileSync('public/sw.js', '');
+  require("fs").writeFileSync("public/sw.js", "");
   //
-  gulp.watch('public/css/**/*.+(css|sass|scss)', ['sass']);
-  gulp.watch('public/js/**/*.js', ['js']);
-
-
+  gulp.watch("public/css/**/*.+(css|sass|scss)", ["sass"]);
+  gulp.watch("public/js/**/*.js", ["js"]);
 });

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
     "gulp-inject": "*",
     "gulp-replace": "*",
     "gulp-sass": "*",
-    "gulp-sourcemaps": "*",
     "gulp-uglify": "*",
-    "gulp-watch": "*",
     "node-sass": "*",
     "sw-precache": "*",
     "sw-toolbox": "*"

--- a/package.json
+++ b/package.json
@@ -2,18 +2,18 @@
   "name": "Magazine",
   "version": "0.1.0",
   "devDependencies": {
-    "gulp": "*",
-    "gulp-autoprefixer": "*",
-    "gulp-concat": "*",
-    "gulp-cssmin": "*",
-    "gulp-import-css": "*",
-    "gulp-inject": "*",
-    "gulp-replace": "*",
-    "gulp-sass": "*",
-    "gulp-uglify": "*",
-    "node-sass": "*",
-    "sw-precache": "*",
-    "sw-toolbox": "*"
+    "gulp": "^4.0.2",
+    "gulp-autoprefixer": "^7.0.0",
+    "gulp-concat": "^2.6.1",
+    "gulp-cssmin": "^0.2.0",
+    "gulp-import-css": "^0.1.3",
+    "gulp-inject": "^5.0.4",
+    "gulp-replace": "^1.0.0",
+    "gulp-sass": "^4.0.2",
+    "gulp-uglify": "^3.0.2",
+    "node-sass": "^4.12.0",
+    "sw-precache": "^5.2.1",
+    "sw-toolbox": "^3.6.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
# What does this PR do?

It updates the gulp file to the [new gulp api](https://gulpjs.com/docs/en/getting-started/creating-tasks).

# Why was this PR needed?

The previous gulp file didn't work with the latest version of gulp. This pull request fixes that.

# How can this PR be tested?

Run `gulp build` or `gulp watch`.

